### PR TITLE
fix: corrige les erreurs d'imports dans RenderSync

### DIFF
--- a/src/components/V20.0_XState/hooks/useRenderSync.js
+++ b/src/components/V20.0_XState/hooks/useRenderSync.js
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { renderSyncService } from '../stores/xstate/machines/renderSyncMachine';
-import { useArtSystemStore } from '../stores/artSystemStore';
+import useSceneStore from '../stores/sceneStore';
 
 /**
  * 🔄 Hook pour utiliser RenderSync dans les composants React
@@ -21,10 +21,10 @@ export function useRenderSync() {
     lighting,
     background,
     setBloomGlobalBatch,
-    setPbrMultipliers,
+    setPbrMultiplier,
     setExposure,
     setBackgroundColor
-  } = useArtSystemStore();
+  } = useSceneStore();
 
   // Initialisation et cleanup
   useEffect(() => {
@@ -70,10 +70,9 @@ export function useRenderSync() {
       }
 
       if (systems.pbr) {
-        setPbrMultipliers({
-          ambientMultiplier: systems.pbr.ambientMultiplier,
-          directionalMultiplier: systems.pbr.directionalMultiplier
-        });
+        // Appliquer les multipliers séparément
+        setPbrMultiplier('ambient', systems.pbr.ambientMultiplier);
+        setPbrMultiplier('directional', systems.pbr.directionalMultiplier);
       }
 
       if (systems.lighting) {

--- a/src/components/V20.0_XState/stores/xstate/machines/renderSyncMachine.js
+++ b/src/components/V20.0_XState/stores/xstate/machines/renderSyncMachine.js
@@ -555,8 +555,8 @@ export class RenderSyncService {
 
   setupStoreListeners() {
     // S'abonner aux changements du store Zustand
-    if (window.useArtSystemStore) {
-      const unsubscribe = window.useArtSystemStore.subscribe(
+    if (window.useSceneStore) {
+      const unsubscribe = window.useSceneStore.subscribe(
         (state) => {
           // Synchroniser les changements vers la machine XState
           this.send({


### PR DESCRIPTION
Résout les erreurs 500 Internal Server Error sur useRenderSync.js

- Remplacé useArtSystemStore par useSceneStore
- Corrigé setPbrMultipliers en appels séparés setPbrMultiplier
- Mis à jour référence window.useArtSystemStore vers window.useSceneStore

Fixes #4

Generated with [Claude Code](https://claude.ai/code)